### PR TITLE
Add Windows OpenSSL ARM64

### DIFF
--- a/deps/sqlcipher-amalgamation-3033000.tar.gz
+++ b/deps/sqlcipher-amalgamation-3033000.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ea4ac71c2103999070a6bb899e3cef3ec0d59356f13cdaf5f5d8857a1895d12
-size 19212286
+oid sha256:262ac32d6a7a4446f1f0e3bd0c76abd9e7bafb84513422f27d43559f5a07bd20
+size 25116284

--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -43,6 +43,11 @@
             'variables': {
               'openssl_root%': 'OpenSSL-Win32',
             }
+          },
+          'target_arch == "arm64"', {
+            'variables': {
+              'openssl_root%': 'OpenSSL-WinARM64',
+            }
           }, {
             'variables': {
               'openssl_root%': 'OpenSSL-Win64',


### PR DESCRIPTION
Adds statically linked binaries for OpenSSL Windows ARM64. Generated with `vcpkg`: `.\vcpkg\vcpkg install openssl:arm64-windows-static`

Needed for https://github.com/signalapp/Signal-Desktop/issues/3745#issuecomment-783263701

Also done in the main `journeyapps/node-sqlcipher` repo (which did updates recently as well): https://github.com/journeyapps/node-sqlcipher/pull/75