### PR TITLE
deps: Use python2 explicitly, to avoid FTBFS on modern systems

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -94,7 +94,7 @@
           'outputs': [
             '<(SHARED_INTERMEDIATE_DIR)/sqlcipher-amalgamation-<@(sqlite_version)/sqlite3.c'
           ],
-          'action': ['python','./extract.py','./sqlcipher-amalgamation-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
+          'action': ['python2','./extract.py','./sqlcipher-amalgamation-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
         }
       ],
       'direct_dependent_settings': {


### PR DESCRIPTION
Modern Linux distributions do not alias `python` to python2. Ptyhon's
PEP394 goes into further detail, but _currently_ you should point to the
Python version you expect to find as `python`.

This fixes various FTBFS on modern Linux/macOS systems with no `python`
alias.

See: https://www.python.org/dev/peps/pep-0394/
See: https://github.com/mapbox/node-sqlite3/issues/1328
See: https://github.com/mapbox/node-sqlite3/issues/584
See: https://github.com/mapbox/node-sqlite3/issues/1443